### PR TITLE
Change :get-root to nil

### DIFF
--- a/lsp-ruby.el
+++ b/lsp-ruby.el
@@ -31,11 +31,6 @@
 (require 'lsp-mode)
 (require 'ruby-mode)
 
-(defconst lsp-ruby--get-root
-  (lsp-make-traverser
-   #'(lambda (dir)
-       (directory-files dir nil "\\(Rakefile\\|Gemfile\\)"))))
-
 (defun lsp-ruby--render-string (str)
   "Render STR with `ruby-mode' syntax highlighting."
   (ignore-errors
@@ -52,13 +47,13 @@
 
 (lsp-define-stdio-client
  lsp-ruby "ruby"
- lsp-ruby--get-root
+ nil
  '("solargraph" "stdio")
  :initialize 'lsp-ruby--initialize-client)
 
 (lsp-define-tcp-client
  lsp-ruby-solargraph-tcp "ruby"
- lsp-ruby--get-root
+ nil
  '("solargraph" "socket")
  "127.0.0.1"
  7658
@@ -66,7 +61,7 @@
 
 (lsp-define-stdio-client
  lsp-ruby-mtsmfm "ruby"
- lsp-ruby--get-root
+ nil
  '("language_server-ruby" "--experimental-features")
  :initialize 'lsp-ruby--initialize-client)
 


### PR DESCRIPTION
Since https://github.com/emacs-lsp/lsp-mode/pull/447
lsp--suggest-project-root (projectile or project.el) will be used instead to detect the root.

Also see https://github.com/emacs-lsp/lsp-python/pull/26